### PR TITLE
Fix software decoder performance

### DIFF
--- a/NativeCode/DecoderFFmpeg.cpp
+++ b/NativeCode/DecoderFFmpeg.cpp
@@ -136,6 +136,8 @@ bool DecoderFFmpeg::init(const char* filePath) {
 		mVideoStream = mAVFormatContext->streams[videoStreamIndex];
 		mVideoCodecContext = mVideoStream->codec;
 		mVideoCodecContext->refcounted_frames = 1;
+		mVideoCodecContext->thread_count = 4;
+		mVideoCodecContext->thread_type = FF_THREAD_FRAME | FF_THREAD_SLICE;
 		mVideoCodec = avcodec_find_decoder(mVideoCodecContext->codec_id);
 		
 		if (mVideoCodec == NULL) {

--- a/UnityPackage/Scripts/MediaDecoder.cs
+++ b/UnityPackage/Scripts/MediaDecoder.cs
@@ -138,7 +138,7 @@ namespace HTC.UnityPlugin.Multimedia
 		private List<float> audioDataBuff = null;   //  Buffer to keep audio data decoded from native.
 		public int audioFrequency { get; private set; }
         public int audioChannels { get; private set; }
-        private const double OVERLAP_TIME = 0.01;   //  Our audio clip is defined as: [overlay][audio data][overlap].
+        private const double OVERLAP_TIME = 0.02;   //  Our audio clip is defined as: [overlay][audio data][overlap].
         private int audioOverlapLength = 0;         //  OVERLAP_TIME * audioFrequency.
         private int audioDataLength = 0;            //  (AUDIO_FRAME_SIZE + 2 * audioOverlapLength) * audioChannel.
         private float volume = 1.0f;
@@ -469,6 +469,7 @@ namespace HTC.UnityPlugin.Multimedia
                                 //  To simplify, the first overlap data would not be played.
                                 //  Correct the audio progress time by adding OVERLAP_TIME.
                                 audioProgressTime = firstAudioFrameTime + OVERLAP_TIME;
+                                globalStartTime = AudioSettings.dspTime - audioProgressTime;
                             }
 
                             while (audioSource[swapIndex].isPlaying || decoderState == DecoderState.SEEK_FRAME) { yield return null; }
@@ -565,7 +566,7 @@ namespace HTC.UnityPlugin.Multimedia
 
                 if (isAudioEnabled) {
                     lock (_lock) {
-                    audioDataBuff.Clear();
+	                    audioDataBuff.Clear();
                     }
                     audioProgressTime = firstAudioFrameTime = -1.0;
                     foreach (AudioSource src in audioSource) {


### PR DESCRIPTION
Increase decoding thread count to improve decoding performance (tested with VP9 software decoding).
Fix livestream decoding by correcting globalStartTime to current stream time when starting decoding.
Increase audio source overlap time to avoid some audio artifacts.